### PR TITLE
fix: url.host != url.hostname

### DIFF
--- a/build/embed.js
+++ b/build/embed.js
@@ -202,7 +202,7 @@ return __p
     var target = opts.schnackTarget;
 
     if (url.hostname != 'localhost') {
-        document.domain = url.host.split('.').slice(1).join('.');
+        document.domain = url.hostname.split('.').slice(1).join('.');
     }
 
     function refresh() {

--- a/src/embed/index.js
+++ b/src/embed/index.js
@@ -19,7 +19,7 @@ import comments_tpl from './comments.jst.html';
     const target = opts.schnackTarget;
 
     if (url.hostname != 'localhost') {
-        document.domain = url.host.split('.').slice(1).join('.');
+        document.domain = url.hostname.split('.').slice(1).join('.');
     }
 
     function refresh() {


### PR DESCRIPTION
url.host includes the port, which is not wanted here.

https://nodejs.org/api/url.html#url_url_host
https://nodejs.org/api/url.html#url_url_hostname

Makes it (partially, see #37) possible to run Schnack on e.g. `schnack.local.host:3000` while the website running on `local.host:4000`.