### PR TITLE
Fix: unchanged default `notify.slack.webhook_url` (xxxxx) doesn't crash app any more

### DIFF
--- a/src/push/slack.js
+++ b/src/push/slack.js
@@ -3,7 +3,7 @@ const request = require('request');
 const config = require('../../config.json');
 const schnackEvents = require('../events');
 
-if (config.notify.slack) {
+if (config.notify.slack && config.notify.slack.webhook_url != 'xxxxx') {
     schnackEvents.on('new-comment', (event) => {
         const post_url = config.page_url.replace('%SLUG%', event.slug)+'#comment-'+event.id;
         const comment = event.comment.split(/\n+/).map(s => s ? `> _${s}_` : '>').join('\n>\n');


### PR DESCRIPTION
Some people might leave the Slack webhook URL unchanged (I did!) which crashes the app. As we know what the default value is, might as well catch that.